### PR TITLE
Move away from using GeoLocation

### DIFF
--- a/assets/js/components/add_interest_form.tsx
+++ b/assets/js/components/add_interest_form.tsx
@@ -93,7 +93,9 @@ export const AddInterestForm = (props: Props) => {
       props.currentLocation?.lng,
       props.fetchedSource.externalId,
       props.fetchedSource.metadata
-    ).then((_) => dispatch({ type: "SUBMITTED" }));
+    )
+      .then((_) => dispatch({ type: "SUBMITTED" }))
+      .catch((_) => dispatch({ type: "SUBMIT_FAILED" }));
   };
 
   return (

--- a/assets/js/components/home.tsx
+++ b/assets/js/components/home.tsx
@@ -4,15 +4,13 @@ import { MapComponent } from "./map_component";
 import { Redirect } from "react-router";
 import { getToken } from "../services/auth_service";
 import { useDebounce } from "../hooks/debounce";
-import { Input } from "semantic-ui-react";
+import { Dimmer, Input, Loader } from "semantic-ui-react";
 import { Coordinate } from "../models/coordinate";
-import { GeolocateControl } from "mapbox-gl";
 import { UserInterest } from "../models/user_interest";
 import { fetchUserInterest } from "../services/interest_service";
 
 interface Props {
-  location: Coordinate | null;
-  geoLocation: GeolocateControl;
+  location: Coordinate;
   switchPage?: (any) => void;
 }
 
@@ -69,13 +67,18 @@ export const Home = (props: Props) => {
           loading={searching}
           onChange={(_event, { value }) => setSearchTerm(value)}
         />
-
-        <MapComponent
-          center={props.location}
-          userInterests={userInterests}
-          geoLocation={props.geoLocation}
-          switchPage={props.switchPage}
-        />
+        {!props.location && (
+          <Dimmer active inverted>
+            <Loader inverted content="Getting your location..." />
+          </Dimmer>
+        )}
+        {props.location && (
+          <MapComponent
+            center={props.location}
+            userInterests={userInterests}
+            switchPage={props.switchPage}
+          />
+        )}
       </>
     );
   }

--- a/assets/js/components/map_component.tsx
+++ b/assets/js/components/map_component.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
-import ReactMapboxGl, { Feature, Layer, Popup } from "react-mapbox-gl";
+import ReactMapboxGl, { Feature, Layer, Marker, Popup } from "react-mapbox-gl";
 
 import { Coordinate } from "../models/coordinate";
-import { GeolocateControl } from "mapbox-gl";
 import { svg } from "./icon";
 import { UserInterest } from "../models/user_interest";
 import { UserInterestMarker } from "./user_interest_marker";
+import { Icon } from "semantic-ui-react";
 
 const Map = ReactMapboxGl({
   accessToken:
@@ -33,7 +33,6 @@ interface Props {
   userInterests: Array<UserInterest>;
   center: Coordinate;
   onStyleLoad?: (map: any) => any;
-  geoLocation: GeolocateControl;
   switchPage?: (any) => void;
 }
 
@@ -89,8 +88,6 @@ export const MapComponent = (props: Props) => {
   const initialState = {
     userInterests: props.userInterests,
     zoom: 13,
-    // centerLat: 40.690008,
-    // centerLng: -73.9857765,
   };
 
   const [state, dispatch] = React.useReducer<React.Reducer<State, Action>>(
@@ -109,15 +106,6 @@ export const MapComponent = (props: Props) => {
     dispatch({ type: "INSTANCE_SELECTED", item: userInterest });
   };
 
-  const onStyleLoad = (map: any) => {
-    const { onStyleLoad } = props;
-    map.addControl(props.geoLocation);
-    setTimeout(() => {
-      props.geoLocation.trigger();
-    }, 500);
-    return onStyleLoad && onStyleLoad(map);
-  };
-
   React.useEffect(() => {
     dispatch({ type: "GOT_CURRENT_LOCATION", coordinate: props.center });
   }, [props.center]);
@@ -131,12 +119,14 @@ export const MapComponent = (props: Props) => {
       style="mapbox://styles/ashkan18/ckhzblkri2mr719n224l706o0"
       containerStyle={mapStyle}
       flyToOptions={flyToOptions}
-      onStyleLoad={onStyleLoad}
       onDrag={onDrag}
       center={state.centerLng && [state.centerLng, state.centerLat]}
       zoom={[state.zoom]}
       movingMethod={"easeTo"}
     >
+      <Marker coordinates={[props.center.lng, props.center.lat]}>
+        <Icon name="user circle outline" color="orange" size="big" />
+      </Marker>
       <Layer type="symbol" id="marker" layout={layoutLayer} images={images}>
         {props.userInterests?.map((bi, index) => (
           <Feature

--- a/assets/js/pages/activity_feed.tsx
+++ b/assets/js/pages/activity_feed.tsx
@@ -1,12 +1,11 @@
 import * as React from "react";
 
-import { Redirect, useParams } from "react-router";
+import { Redirect } from "react-router";
 import {
   Dimmer,
   Divider,
   Feed,
   Header,
-  Icon,
   Loader,
   Image,
 } from "semantic-ui-react";

--- a/assets/js/pages/main.tsx
+++ b/assets/js/pages/main.tsx
@@ -1,8 +1,6 @@
-import { GeolocateControl } from "mapbox-gl";
 import React from "react";
 import { Header } from "../components/header";
 import MainLayout from "../components/main_layout";
-import { Coordinate } from "../models/coordinate";
 import Reader from "../models/reader";
 import { getMe } from "../services/user_service";
 import { Home } from "../components/home";
@@ -13,22 +11,15 @@ import { ProfilePage } from "./profile_page";
 import { MyFeed } from "./activity_feed";
 
 export const Main = () => {
-  const geoLocation = new GeolocateControl({
-    positionOptions: {
-      enableHighAccuracy: false,
-    },
-    trackUserLocation: false,
-  });
   const [me, setMe] = React.useState<Reader | null>(null);
   const [needsLogin, setNeedsLogin] = React.useState(false);
   const [currentLocation, setCurrentLocation] = React.useState<any | null>(
     null
   );
 
-  geoLocation.on("geolocate", (data) => {
-    const { latitude, longitude } = data.coords;
-    const coords: Coordinate = { lat: latitude, lng: longitude };
-    setCurrentLocation(coords);
+  navigator.geolocation.getCurrentPosition((position) => {
+    const { latitude, longitude } = position.coords;
+    setCurrentLocation({ lat: latitude, lng: longitude });
   });
 
   React.useEffect(() => {
@@ -61,7 +52,7 @@ export const Main = () => {
           <ProfilePage />
         </Route>
         <Route path="/">
-          <Home geoLocation={geoLocation} location={currentLocation} />
+          <Home location={currentLocation} />
         </Route>
       </Switch>
     </MainLayout>


### PR DESCRIPTION
# Problem
Right now we get user's location only when map is shown and every time it's rendered. This causes issues on pages where map is not shown, we don't have user's location.

Potential other issue is, this was constantly getting user's location but we could just have it as one time thing.

This also caused the weirdness about starting the empty map from London and then jumping to where you actually are.

# Solution
Get user's location once in `main.tsx` using `geolocation.getCurrentPosition`, don't show the map till we get the location and then we show user's current location on the map.